### PR TITLE
🐛 無限スーモしてスーモ文字列含めてTweetすると、Twitterの受付可能クエリパラメーターの文字列長さ超過を起こす不具合の修正

### DIFF
--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -122,10 +122,8 @@ function init_order(array, option) {
         if (this.id == "tweet2") {
           if (lyrics == "") {
             window.alert("スーモ文字列が空のままです．再生してからツイートすることをおすすめします");
-          } else if (lyrics.length > 356){
-              lyrics = lyrics.substring(0, 357)
           }
-          window.open('http://twitter.com/intent/tweet/?text=' + encodeURIComponent(lyrics) + '&url=' + encodeURIComponent("http://hnakai0909.github.io/works/suumo/"));
+          window.open('http://twitter.com/intent/tweet/?text=' + encodeURIComponent(lyrics.substring(0, 600)) + '&url=' + encodeURIComponent("http://hnakai0909.github.io/works/suumo/"));
           return;
         } else if (this.id == 'stop') {
           //音の再生を止める

--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -122,6 +122,8 @@ function init_order(array, option) {
         if (this.id == "tweet2") {
           if (lyrics == "") {
             window.alert("スーモ文字列が空のままです．再生してからツイートすることをおすすめします");
+          } else if (lyrics.length > 356){
+              lyrics = lyrics.substring(0, 357)
           }
           window.open('http://twitter.com/intent/tweet/?text=' + encodeURIComponent(lyrics) + '&url=' + encodeURIComponent("http://hnakai0909.github.io/works/suumo/"));
           return;


### PR DESCRIPTION
# 無限スーモしてスーモ文字列含めてTweetすると、Twitterの受付可能クエリパラメーターの文字列長さ超過を起こす不具合の修正

無限スーモで楽しく遊ばせていただいていたところ次のような不具合がありましたのでPRを出します。
(スーモ楽しくてついついPR出してしまいました。)

## 事象
一定文字数を超えたTweet文字列がシェア用URLのクエリパラメーター`text`に入ると、HTTP 413(Request Entity Too Large)のエラーが返ってくる。

![2021-03-30_22h12_32](https://user-images.githubusercontent.com/9511227/112999984-5dda7d80-91aa-11eb-85fc-aefd5966baef.png)

## 修正

適当なスーモ文字列の長さ以上になった場合subsrtingしたうえでシェアURLのtextパラメーターに連携する。

- いったん600文字にしました。が、そもそもtwitterの最大文字数は140文字なのでそちらに合わせてもいいかもしれません。