### PR TITLE
複数再生周りのバグ修正

### DIFF
--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -226,8 +226,11 @@ function init_order(array, option) {
             t0 += interval;
             source.onended = (function (i) {
               return function () {
-                lyric_elements[i].style.background = lyricBGStyleNormal;
                 livingSources.splice(livingSources.indexOf(this), 1);
+
+                if (lyric_elements[i]) {
+                  lyric_elements[i].style.background = lyricBGStyleNormal;
+                }
 
                 if (mode === "infinity" && i === sources.length - 4) {
                   addSuumo(t0, true)

--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -73,6 +73,7 @@ function init_order(array, option) {
     var buffers = new Array(suumo.length);          // for the instances of AudioBufferSourceNode
     var lyric_elements = new Array(suumo.length);
 
+    var livingSources = [];
     var sources = [];
     var interval;  // sec
 
@@ -147,10 +148,11 @@ function init_order(array, option) {
           return;
         } else if (this.id == 'stop') {
           //音の再生を止める
-          sources.forEach(function (source) {
+          livingSources.forEach(function (source) {
             source.onended = function () { };
             source.stop(0);
           });
+          livingSources = [];
           sources = [];
           //赤反転を消す
           lyric_elements.forEach(function (element) {
@@ -225,6 +227,7 @@ function init_order(array, option) {
             source.onended = (function (i) {
               return function () {
                 lyric_elements[i].style.background = lyricBGStyleNormal;
+                livingSources.splice(livingSources.indexOf(this), 1);
 
                 if (mode === "infinity" && i === sources.length - 4) {
                   addSuumo(t0, true)
@@ -237,6 +240,7 @@ function init_order(array, option) {
                 }
               }
             })(startIndex + i);
+            livingSources.push(source);
             sources.push(source);
           });
         }

--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -73,7 +73,7 @@ function init_order(array, option) {
     var buffers = new Array(suumo.length);          // for the instances of AudioBufferSourceNode
     var lyric_elements = new Array(suumo.length);
 
-    var livingSources = [];
+    var livingSources = [];                           // will playing sources
     var sources = [];
     var interval;  // sec
 
@@ -235,7 +235,9 @@ function init_order(array, option) {
 
                 if (i < sources.length - 1) {
                   lyric_elements[i + 1].style.background = lyricBgStyleCurrent;
-                } else {
+                }
+
+                if (livingSources.length === 0) {
                   sources = [];
                 }
               }


### PR DESCRIPTION
愉快なWebサイトをありがとうございます。

複数スーモ時の以下の点について、不具合っぽい動きを見つけましたので、修正しました。

- `止ボタン`で最後のスーモしか止められないが、背景色はすべて削除される
- 終了スーモが生まれるとすべての生存スーモの背景色が消えてしまう
- 無限スーモでリリックが増えたり減ったりした時にコンソールエラーが出ている


再生中のスーモを管理するため、`livingSources`という変数を作成しています。

もしよければ、お取り込みください。