### PR TITLE
無限,ふつう(ランダムでない)モードを追加＋音量の初期化(70%)・現在値表示機能拡張

### DIFF
--- a/works/suumo/index.html
+++ b/works/suumo/index.html
@@ -56,7 +56,8 @@
   <div id="caution">ボタンを押すと音が出ます。音量にご注意ください。</div>
   <button type="button" id="normal" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(ふつう)</button>
   <button type="button" id="random" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(ランダム)</button>
-  <button type="button" id="infinity" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(無限)</button>
+  <button type="button" id="infinity-normal" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(無限,ふつう)</button>
+  <button type="button" id="infinity" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(無限,ランダム)</button>
   <button type="button" id="stop" style="width:60px;height:60px;font-size:30px;text-align:center;">止</button>
   <table><tbody>
     <tr id="volume_box">

--- a/works/suumo/index.html
+++ b/works/suumo/index.html
@@ -64,15 +64,14 @@
       <td>音量(開始時のみ反映)</td>
       <td>
         <input type="range" id="volume_slider" min="0" max="1" step="0.01" value="0.7" style="width:200px;height:20px;">
-        <span id="volume_slider_value" style="display:inline-block;width:50px;">70%</span>
-        <button type="button" id="volume_reset" style="width:60px;height:40px;font-size:16px;">70%</button>
+        <span id="volume_slider_value">70%</span>
       </td>
     </tr>
     <tr id="rate_box">
       <td>再生速度(開始時のみ反映)</td>
       <td>
         <input type="range" id="rate_slider" min="-2" max="2" step="0.01" value="0" style="width:200px;height:20px;">
-        <span id="rate_slider_value" style="display:inline-block;width:50px;">x1.00</span>
+        <span id="rate_slider_value">x1.00</span>
         <button type="button" id="rate_reset" style="width:60px;height:40px;font-size:16px;">x1.00</button>
       </td>
       <td>再生速度ランダム(スライドバー無視)</td>

--- a/works/suumo/index.html
+++ b/works/suumo/index.html
@@ -64,14 +64,15 @@
       <td>音量(開始時のみ反映)</td>
       <td>
         <input type="range" id="volume_slider" min="0" max="1" step="0.01" value="0.7" style="width:200px;height:20px;">
-        <span id="volume_slider_value">70%</span>
+        <span id="volume_slider_value" style="display:inline-block;width:50px;">70%</span>
+        <button type="button" id="volume_reset" style="width:60px;height:40px;font-size:16px;">70%</button>
       </td>
     </tr>
     <tr id="rate_box">
       <td>再生速度(開始時のみ反映)</td>
       <td>
         <input type="range" id="rate_slider" min="-2" max="2" step="0.01" value="0" style="width:200px;height:20px;">
-        <span id="rate_slider_value">x1.00</span>
+        <span id="rate_slider_value" style="display:inline-block;width:50px;">x1.00</span>
         <button type="button" id="rate_reset" style="width:60px;height:40px;font-size:16px;">x1.00</button>
       </td>
       <td>再生速度ランダム(スライドバー無視)</td>

--- a/works/suumo/index.html
+++ b/works/suumo/index.html
@@ -56,8 +56,8 @@
   <div id="caution">ボタンを押すと音が出ます。音量にご注意ください。</div>
   <button type="button" id="normal" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(ふつう)</button>
   <button type="button" id="random" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(ランダム)</button>
-  <button type="button" id="infinity-normal" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(無限,ふつう)</button>
-  <button type="button" id="infinity" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(無限,ランダム)</button>
+  <button type="button" id="infinity-normal" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(ふつう無限)</button>
+  <button type="button" id="infinity" style="width:600px;height:80px;font-size:45px;">あ！スーモ！(ランダム無限)</button>
   <button type="button" id="stop" style="width:60px;height:60px;font-size:30px;text-align:center;">止</button>
   <table><tbody>
     <tr id="volume_box">

--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -166,6 +166,10 @@
             rateSlider.value = 0;
             updateRateSliderValue();
             break;
+          case 'volume_reset':
+            volumeSlider.value = 0.7;
+            updateVolumeSliderValue();
+            break;
           default:  // いずれかのあ！スーモ！再生ボタンのとき
             startSuumo(this.id);
             break;

--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -166,10 +166,6 @@
             rateSlider.value = 0;
             updateRateSliderValue();
             break;
-          case 'volume_reset':
-            volumeSlider.value = 0.7;
-            updateVolumeSliderValue();
-            break;
           default:  // いずれかのあ！スーモ！再生ボタンのとき
             startSuumo(this.id);
             break;

--- a/works/suumo/main.js
+++ b/works/suumo/main.js
@@ -31,8 +31,9 @@
     'normal': 0,
     'random': 1,
     'infinity': 2,
+    'infinity-normal': 3,
   };
-  const noRandomModes = [0];  // 基本的にはランダムモードが追加されていくことを想定
+  const noRandomModes = [0, 3];  // 基本的にはランダムモードが追加されていくことを想定
 
   var song = new Array(suumo.length);
   var lyricsText = "";
@@ -297,7 +298,7 @@
               deactivateLyricElement(index);
             }
 
-            if (modeId === modes['infinity'] && isAlmostFinishOfSuumo(index)) {
+            if ((modeId === modes['infinity'] || modeId === modes['infinity-normal']) && isAlmostFinishOfSuumo(index)) {
               addSuumo(t0, true, true, modeId);
             }
 


### PR DESCRIPTION
先に"音量現在値表示を追加"のプルリクエストをさせていただきましたが、
今回は下記3機能を実装しました。

**1.無限,ふつう(ランダムでない)モードを追加**
　※既存の無限モードはランダムのみのため
**2.音量の初期化(70%)ボタン追加**
　…再生速度表示との統一性を上げるため
　　(音量については、耳を保護するためにランダム機能はいらないと思います。)
**3.音量、再生速度表示についてspanの横幅を定数定義(50px)**

よろしければマージ願います。
※ラベルは"enhancement"にあたります

_蛇足：ツイート機能について、ツイート文に何かしらハッシュタグを付けてみるといいかもしれません_